### PR TITLE
Fix memory leak in SearchRequestView and Template

### DIFF
--- a/lib/esse/jbuilder/search_request_view.rb
+++ b/lib/esse/jbuilder/search_request_view.rb
@@ -3,13 +3,40 @@
 module Esse
   module Jbuilder
     class SearchRequestView < ::ActionView::Base
-      def initialize(assings = {})
-        lookup_context = ::ActionView::LookupContext.new(Esse.config.search_view_path)
-        super(lookup_context, assings, nil)
+      # Isolate compiled template methods in a dedicated module instead of
+      # accumulating them directly on the class. This prevents unbounded
+      # method growth on SearchRequestView over the lifetime of the process.
+      module CompiledTemplates
+      end
+      include CompiledTemplates
+
+      def initialize(assigns = {})
+        super(self.class.lookup_context, assigns, nil)
       end
 
       def compiled_method_container
-        self.class
+        CompiledTemplates
+      end
+
+      # Returns a cached LookupContext, automatically invalidated when
+      # Esse.config.search_view_path changes.
+      def self.lookup_context
+        current_path = Esse.config.search_view_path
+        if @lookup_context_path != current_path
+          @lookup_context_path = current_path
+          @lookup_context = ::ActionView::LookupContext.new(current_path)
+        end
+        @lookup_context
+      end
+
+      # Clears the cached LookupContext and all compiled template methods.
+      # Useful for development/testing when templates or paths change.
+      def self.reset!
+        @lookup_context = nil
+        @lookup_context_path = nil
+        CompiledTemplates.instance_methods.each do |method_name|
+          CompiledTemplates.remove_method(method_name)
+        end
       end
     end
   end

--- a/lib/esse/jbuilder/template.rb
+++ b/lib/esse/jbuilder/template.rb
@@ -26,6 +26,15 @@ module Esse
         new(view_filename, **assigns).to_hash(&block)
       end
 
+      def self.read_template(file_path)
+        @template_cache ||= {}
+        @template_cache[file_path] ||= File.read(file_path)
+      end
+
+      def self.reset_template_cache!
+        @template_cache = {}
+      end
+
       def initialize(view_filename = nil, **assigns)
         @view_filename = view_filename
         @assigns = assigns
@@ -38,9 +47,10 @@ module Esse
           filename = fragments.pop
           filename = "#{filename}.json.jbuilder" unless filename.end_with?(".json.jbuilder")
           rel_path = fragments.join("/")
+          file_path = Esse.config.search_view_path.join("#{rel_path}/#{filename}").to_s
 
           ->(json) {
-            json.instance_eval(File.read(Esse.config.search_view_path.join("#{rel_path}/#{filename}").to_s), view_filename, 1)
+            json.instance_eval(self.class.read_template(file_path), view_filename, 1)
           }
         end
 

--- a/lib/esse/jbuilder/version.rb
+++ b/lib/esse/jbuilder/version.rb
@@ -2,6 +2,6 @@
 
 module Esse
   module Jbuilder
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end


### PR DESCRIPTION
## Summary

- **Isolate compiled template methods** in a dedicated `CompiledTemplates` module instead of accumulating them on `SearchRequestView` class, preventing unbounded method growth over the process lifetime
- **Cache `ActionView::LookupContext`** at the class level with automatic invalidation when `search_view_path` changes, avoiding creation of a heavy object on every search query
- **Cache template file reads** in `Template.read_template` to avoid repeated disk I/O on every invocation
- Add `SearchRequestView.reset!` and `Template.reset_template_cache!` for development/testing reloading
- Bump version to 0.0.5

## Test plan

- [x] All existing specs pass (15 examples, 0 failures)
- [x] Syntax check passes on all modified files
- [ ] Verify memory usage in production with `memory_profiler` or RSS monitoring