### PR TITLE
docs: add usage and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Extends the [esse](https://github.com/marcosgz/esse) search to use [jbuilder](https://github.com/rails/jbuilder) as the default template engine.
 
+## Documentation
+
+Full guides, template configuration, and API reference are published at **[gems.marcosz.com.br/esse-jbuilder](https://gems.marcosz.com.br/esse-jbuilder/)** — part of the [marcosgz Ruby gem catalogue](https://gems.marcosz.com.br).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# esse-jbuilder
+
+Build Elasticsearch/OpenSearch search bodies with [Jbuilder](https://github.com/rails/jbuilder) instead of nested Ruby hashes. Plays nicely with [Esse](../../esse/docs/README.md) out of the box.
+
+## Contents
+
+- [Usage guide](usage.md)
+- [API reference](api.md)
+
+## What you get
+
+- Use Jbuilder blocks directly inside `UsersIndex.search { |json| ... }`.
+- Render `.json.jbuilder` template files from `app/searches/`.
+- Works across multiple indices (`Esse.cluster.search(Index1, Index2) { |json| ... }`).
+
+## Quick start
+
+```ruby
+# Gemfile
+gem 'esse', '>= 0.2.4'
+gem 'esse-jbuilder'
+```
+
+```ruby
+# Inline
+results = UsersIndex.search do |json|
+  json.query do
+    json.match do
+      json.set! 'name', params[:q]
+    end
+  end
+end
+
+# From a template file (Rails only)
+body    = Esse::Jbuilder::ViewTemplate.call('users/search', q: params[:q])
+results = UsersIndex.search(body: body)
+```
+
+## Configuration
+
+One option:
+
+```ruby
+Esse.configure do |config|
+  config.search_view_path = 'app/searches' # default
+end
+```
+
+## Version
+
+- Version: **0.0.5**
+- Ruby: `>= 2.5.0`
+- Depends on: `esse >= 0.2.4`, `jbuilder >= 2`
+
+## License
+
+MIT.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,99 @@
+# API Reference
+
+## Configuration
+
+### `Esse::Config#search_view_path`
+
+Added to `Esse::Config`. Default: `Pathname('app/searches')`.
+
+```ruby
+Esse.configure do |config|
+  config.search_view_path = 'app/searches'        # String
+  config.search_view_path = Pathname('searches')  # Pathname
+end
+```
+
+Read back:
+
+```ruby
+Esse.config.search_view_path # => Pathname
+```
+
+---
+
+## `Esse::Jbuilder::Template`
+
+Renders a Jbuilder block or a `.json.jbuilder` file into a Hash, independent of Rails.
+
+### `.call(view_filename = nil, **assigns, &block)` → Hash
+
+- If a block is given, renders the block.
+- If `view_filename` is given, renders the file from `search_view_path`.
+- `assigns` are exposed as `@variables` in the template.
+
+```ruby
+# From a block
+body = Esse::Jbuilder::Template.call do |json|
+  json.query { json.match { json.set! 'name', 'John' } }
+end
+
+# From a file
+body = Esse::Jbuilder::Template.call('cities/search', name: 'Chicago')
+```
+
+### Instance methods
+
+- `initialize(view_filename = nil, **assigns)`
+- `to_hash(&block)` — the actual rendering.
+
+---
+
+## `Esse::Jbuilder::ViewTemplate`
+
+Renders a Jbuilder template through Rails' ActionView pipeline. Requires Rails (ActionView) to be loaded. Supports `partial!`, helpers, and full view lookup.
+
+### `.call(view_filename, assigns = {})` → Hash
+
+```ruby
+body = Esse::Jbuilder::ViewTemplate.call('cities/search', name: 'Chicago')
+```
+
+### Class attributes
+
+- `symbolize_keys` — default `false`. When `true`, the resulting hash uses Symbol keys.
+
+### Instance methods
+
+- `initialize(view_filename, assigns = {})`
+- `to_hash` — renders via ActionView.
+
+---
+
+## `Esse::Jbuilder::WithAssigns`
+
+Internal Jbuilder subclass. Used to inject `@assigns` into the template context.
+
+- `__assign(key)` — retrieve an assigned variable by name.
+
+You don't need to use this directly.
+
+---
+
+## `Esse::Jbuilder::SearchRequestView`
+
+Internal ActionView base class used by `ViewTemplate` for the render context.
+
+- `.lookup_context` (class-level, memoized) — returns the `ActionView::LookupContext`.
+
+Not part of the public API.
+
+---
+
+## Integration points
+
+On load the gem:
+
+1. Extends `Esse::Config` with `search_view_path` / `search_view_path=`.
+2. Prepends `Esse::Jbuilder::SearchQuery::InstanceMethods` into `Esse::Search::Query`, teaching the query to accept Jbuilder blocks.
+
+No explicit `plugin :jbuilder` call is needed — just `require 'esse/jbuilder'` (or have it in your Gemfile).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,162 @@
+# Usage Guide
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'esse-jbuilder'
+```
+
+Loading the gem prepends Jbuilder-aware behavior to `Esse::Search::Query`.
+
+## Inline Jbuilder
+
+Pass a block to any `search` call and the block becomes the search body:
+
+```ruby
+query = UsersIndex.search do |json|
+  json.query do
+    json.match do
+      json.set! 'name', params[:q]
+    end
+  end
+end
+
+query.response.results
+```
+
+For complex queries, Jbuilder's DSL is often easier than nested hashes:
+
+```ruby
+UsersIndex.search do |json|
+  json.query do
+    json.bool do
+      json.must do
+        json.child! do
+          json.match { json.set! 'name', params[:q] }
+        end
+      end
+      if (states = params[:state_abbr])
+        json.filter do
+          json.child! do
+            json.terms { json.set! 'state_abbr', states }
+          end
+        end
+      end
+    end
+  end
+
+  json.aggs do
+    json.states do
+      json.terms { json.set! 'field', 'state_abbr' }
+    end
+  end
+end
+```
+
+Multiple indices work the same way:
+
+```ruby
+Esse.cluster.search(CitiesIndex, CountiesIndex) do |json|
+  json.query do
+    json.match_all
+  end
+end
+```
+
+## Template files
+
+Set the template directory (default `app/searches`):
+
+```ruby
+Esse.configure do |config|
+  config.search_view_path = 'app/searches'
+end
+```
+
+Create `app/searches/cities/search.json.jbuilder`:
+
+```jbuilder
+json.query do
+  json.match do
+    json.set! 'name', @name
+  end
+end
+```
+
+Render it:
+
+```ruby
+body = Esse::Jbuilder::Template.call('cities/search', name: 'Chicago')
+CitiesIndex.search(body: body)
+```
+
+## Rails view templates
+
+`Esse::Jbuilder::ViewTemplate` uses Rails' ActionView lookup so you can include partials and share them with normal Rails views:
+
+```ruby
+# app/searches/cities/search.json.jbuilder
+json.query do
+  json.match do
+    json.set! 'name', @name
+  end
+end
+json.partial! 'shared/pagination', page: @page
+```
+
+```ruby
+body = Esse::Jbuilder::ViewTemplate.call('cities/search', name: params[:q], page: params[:page])
+CitiesIndex.search(body: body)
+```
+
+ViewTemplate must be called in a Rails process (needs `ActionView`). It uses your app's full view lookup context, including partials and helpers.
+
+### Symbol keys
+
+By default `ViewTemplate` returns string-keyed hashes. Opt into symbols globally:
+
+```ruby
+Esse::Jbuilder::ViewTemplate.symbolize_keys = true
+```
+
+## Searcher pattern
+
+A tidy pattern for non-trivial queries:
+
+```ruby
+class Searchers::CitiesSearcher
+  extend Forwardable
+  def_delegators :search, :response, :results
+
+  def initialize(params)
+    @params = params.symbolize_keys
+  end
+
+  def call
+    search
+  end
+
+  private
+
+  def search
+    @search ||= CitiesIndex
+      .search(body: body)
+      .limit(@params.fetch(:limit, 10))
+      .offset(@params.fetch(:offset, 0))
+  end
+
+  def body
+    Esse::Jbuilder::ViewTemplate.call('cities/search', **@params)
+  end
+end
+
+Searchers::CitiesSearcher.new(params).call.results
+```
+
+## Tips
+
+- Jbuilder's `json.set!` avoids method-name collisions with Ruby keywords or symbols ES expects (`match_all`, `terms`, etc.).
+- Use `json.child!` to build arrays inside `must`, `filter`, `should`, etc.
+- Helpers defined in `ApplicationHelper` are available inside `ViewTemplate` because it uses the standard Rails view context.


### PR DESCRIPTION
## Summary

Adds `docs/` with three files:

- `README.md` — overview and entry point
- `usage.md` — how to define documents with Jbuilder templates
- `api.md` — reference for the template-renderer integration

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify template examples match the current API
- [ ] Verify `api.md` module names are correct